### PR TITLE
이용 기간에 따른 만료 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.batch:spring-batch-test'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spring/pass/config/BatchConfig.java
+++ b/src/main/java/com/spring/pass/config/BatchConfig.java
@@ -1,0 +1,16 @@
+package com.spring.pass.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * <h3>@EnableBatchProcessing</h3>
+ * <ul>
+ *     <li>Spring Batch 기능을 활성화하고 배치 작업을 설정하기 위한 기본 구성을 제공</li>
+ *     <li>JobRepository, JobLauncher, JobRegistry, PlatformTransactionManager, JobBuilderFactory, StepBuilderFactory 을 빈으로 제공</li>
+ * </ul>
+ */
+@EnableBatchProcessing
+@Configuration
+public class BatchConfig {
+}

--- a/src/main/java/com/spring/pass/domain/PassTicket.java
+++ b/src/main/java/com/spring/pass/domain/PassTicket.java
@@ -1,6 +1,6 @@
 package com.spring.pass.domain;
 
-import com.spring.pass.domain.constant.PassStatus;
+import com.spring.pass.domain.constant.PassTicketStatus;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -20,7 +20,7 @@ public class PassTicket extends AuditingFields {
     private String userId; //사용자 ID
 
     @Enumerated(EnumType.STRING)
-    private PassStatus status; //이용권 상태
+    private PassTicketStatus status; //이용권 상태
     private Integer remainingCount; //남은 횟수
 
     private LocalDateTime startedAt; //시작 일시
@@ -30,7 +30,7 @@ public class PassTicket extends AuditingFields {
     protected PassTicket() {
     }
 
-    private PassTicket(Long packageId, String userId, PassStatus status, Integer remainingCount, LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime expiredAt) {
+    private PassTicket(Long packageId, String userId, PassTicketStatus status, Integer remainingCount, LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime expiredAt) {
         this.packageId = packageId;
         this.userId = userId;
         this.status = status;
@@ -40,8 +40,16 @@ public class PassTicket extends AuditingFields {
         this.expiredAt = expiredAt;
     }
 
-    public static PassTicket of(Long packageId, String userId, PassStatus status, Integer remainingCount, LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime expiredAt) {
+    public static PassTicket of(Long packageId, String userId, PassTicketStatus status, Integer remainingCount, LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime expiredAt) {
         return new PassTicket(packageId, userId, status, remainingCount, startedAt, endedAt, expiredAt);
+    }
+
+    public void expire () {
+        this.expiredAt = LocalDateTime.now();
+    }
+
+    public void changeStatus(PassTicketStatus status) {
+        this.status = status;
     }
 
     @Override

--- a/src/main/java/com/spring/pass/domain/UserAccount.java
+++ b/src/main/java/com/spring/pass/domain/UserAccount.java
@@ -1,6 +1,6 @@
 package com.spring.pass.domain;
 
-import com.spring.pass.domain.constant.UserStatus;
+import com.spring.pass.domain.constant.UserAccountStatus;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -17,14 +17,14 @@ public class UserAccount extends AuditingFields {
     private String userName; //사용자 이름
 
     @Enumerated(EnumType.STRING)
-    private UserStatus status; //사용자 상태
+    private UserAccountStatus status; //사용자 상태
     private String phone; //폰 번호
     private String meta; //메타 정보(JSON)
 
     protected UserAccount() {
     }
 
-    private UserAccount(String userId, String userName, UserStatus status, String phone, String meta) {
+    private UserAccount(String userId, String userName, UserAccountStatus status, String phone, String meta) {
         this.userId = userId;
         this.userName = userName;
         this.status = status;
@@ -32,7 +32,7 @@ public class UserAccount extends AuditingFields {
         this.meta = meta;
     }
 
-    public static UserAccount of(String userId, String userName, UserStatus status, String phone, String meta) {
+    public static UserAccount of(String userId, String userName, UserAccountStatus status, String phone, String meta) {
         return new UserAccount(userId, userName, status, phone, meta);
     }
 

--- a/src/main/java/com/spring/pass/domain/constant/BookingStatus.java
+++ b/src/main/java/com/spring/pass/domain/constant/BookingStatus.java
@@ -6,5 +6,5 @@ package com.spring.pass.domain.constant;
  * READY, IN_PROGRESS, COMPLETED, CANCELLED
  */
 public enum BookingStatus {
-    READY, IN_PROGRESS, COMPLETED, CANCELLED
+    READY, PROGRESSED, COMPLETED, CANCELLED
 }

--- a/src/main/java/com/spring/pass/domain/constant/PassTicketStatus.java
+++ b/src/main/java/com/spring/pass/domain/constant/PassTicketStatus.java
@@ -5,6 +5,6 @@ package com.spring.pass.domain.constant;
  * <br><br>
  * READY, IN_PROGRESS, EXPIRED
  */
-public enum PassStatus {
-    READY, IN_PROGRESS, EXPIRED
+public enum PassTicketStatus {
+    READY, PROGRESSED, EXPIRED
 }

--- a/src/main/java/com/spring/pass/domain/constant/UserAccountStatus.java
+++ b/src/main/java/com/spring/pass/domain/constant/UserAccountStatus.java
@@ -5,6 +5,6 @@ package com.spring.pass.domain.constant;
  * <br><br>
  * ACTIVE, INACTIVE
  */
-public enum UserStatus {
+public enum UserAccountStatus {
     ACTIVE, INACTIVE
 }

--- a/src/main/java/com/spring/pass/job/passticket/ExpirePassTicketsJobConfig.java
+++ b/src/main/java/com/spring/pass/job/passticket/ExpirePassTicketsJobConfig.java
@@ -1,0 +1,75 @@
+package com.spring.pass.job.passticket;
+
+import com.spring.pass.domain.PassTicket;
+import com.spring.pass.domain.constant.PassTicketStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JpaCursorItemReader;
+import org.springframework.batch.item.database.JpaItemWriter;
+import org.springframework.batch.item.database.builder.JpaCursorItemReaderBuilder;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Configuration
+public class ExpirePassTicketsJobConfig {
+    private final int CHUNK_SIZE = 1;
+
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final EntityManagerFactory entityManagerFactory;
+
+    @Bean
+    public Job expirePassTicketsJob() {
+        return jobBuilderFactory.get("expirePassTicketsJob")
+                .start(expirePassTicketsStep())
+                .build();
+    }
+
+    @Bean
+    public Step expirePassTicketsStep() {
+        return stepBuilderFactory.get("expirePassTicketsStep")
+                .<PassTicket, PassTicket>chunk(CHUNK_SIZE)
+                .reader(expirePassTicketsItemReader())
+                .processor(expirePassTicketsItemProcessor())
+                .writer(expirePassTicketsItemWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public JpaCursorItemReader<PassTicket> expirePassTicketsItemReader() {
+        return new JpaCursorItemReaderBuilder<PassTicket>()
+                .name("expirePassTicketsItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("select p from PassTicket p where p.status = :status and p.endedAt <= :endedAt order by p.id")
+                .parameterValues(Map.of("status", PassTicketStatus.PROGRESSED, "endedAt", LocalDateTime.now()))
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<PassTicket, PassTicket> expirePassTicketsItemProcessor() {
+        return passTicket -> {
+            passTicket.changeStatus(PassTicketStatus.EXPIRED);
+            passTicket.expire();
+            return passTicket;
+        };
+    }
+
+    @Bean
+    public JpaItemWriter<PassTicket> expirePassTicketsItemWriter() {
+        return new JpaItemWriterBuilder<PassTicket>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -17,7 +17,7 @@ VALUES ('A1000000', '우영우', 'ACTIVE', '01011112222', NULL, '2022-08-01 00:0
        ('B2000001', '태수미', 'ACTIVE', '01000001111', NULL, '2022-08-01 00:00:00');
 
 INSERT INTO pass_ticket (package_id, user_id, status, remaining_count, started_at, ended_at, expired_at, created_at) VALUES
-    (1, 'A1000000', 'IN_PROGRESS', 100, '2022-08-15 00:00:00', '2022-08-16 00:00:00', NULL, '2022-08-15 00:00:00');
+    (1, 'A1000000', 'PROGRESSED', 100, '2022-08-15 00:00:00', '2022-08-16 00:00:00', NULL, '2022-08-15 00:00:00');
 
 INSERT INTO booking (pass_ticket_id, user_id, status, used_pass, attended, started_at, ended_at, cancelled_at, created_at) VALUES
-    (1, 'A1000000', 'IN_PROGRESS', true, true, '2022-08-15 00:00:00', '2022-08-16 00:00:00', NULL, '2022-08-15 00:00:00')
+    (1, 'A1000000', 'PROGRESSED', true, true, '2022-08-15 00:00:00', '2022-08-16 00:00:00', NULL, '2022-08-15 00:00:00')

--- a/src/test/java/com/spring/pass/PassBatchApplicationTests.java
+++ b/src/test/java/com/spring/pass/PassBatchApplicationTests.java
@@ -2,7 +2,9 @@ package com.spring.pass;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class PassBatchApplicationTests {
 

--- a/src/test/java/com/spring/pass/config/TestBatchConfig.java
+++ b/src/test/java/com/spring/pass/config/TestBatchConfig.java
@@ -1,0 +1,17 @@
+package com.spring.pass.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@TestConfiguration
+@EnableAutoConfiguration
+@EnableBatchProcessing
+@EntityScan("com.spring.pass.domain")
+@EnableJpaRepositories("com.spring.pass.repository")
+@EnableTransactionManagement
+public class TestBatchConfig {
+}

--- a/src/test/java/com/spring/pass/config/TestJpaConfig.java
+++ b/src/test/java/com/spring/pass/config/TestJpaConfig.java
@@ -1,0 +1,9 @@
+package com.spring.pass.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfig {
+}

--- a/src/test/java/com/spring/pass/job/passticket/ExpirePassTicketsJobConfigTest.java
+++ b/src/test/java/com/spring/pass/job/passticket/ExpirePassTicketsJobConfigTest.java
@@ -1,0 +1,78 @@
+package com.spring.pass.job.passticket;
+
+import com.spring.pass.config.TestBatchConfig;
+import com.spring.pass.config.TestJpaConfig;
+import com.spring.pass.domain.PassTicket;
+import com.spring.pass.domain.constant.PassTicketStatus;
+import com.spring.pass.repository.PassTicketRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBatchTest
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {
+        ExpirePassTicketsJobConfig.class,
+        TestBatchConfig.class,
+        TestJpaConfig.class
+})
+class ExpirePassTicketsJobConfigTest {
+    private JobLauncherTestUtils jobLauncherTestUtils;
+    private PassTicketRepository passTicketRepository;
+
+    @Autowired
+    public ExpirePassTicketsJobConfigTest(JobLauncherTestUtils jobLauncherTestUtils, PassTicketRepository passTicketRepository) {
+        this.jobLauncherTestUtils = jobLauncherTestUtils;
+        this.passTicketRepository = passTicketRepository;
+    }
+
+    @Test
+    public void expirePassTicketsStep() throws Exception {
+        // Given
+        addPassEntities(10);
+        // When
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob();
+        JobInstance jobInstance = jobExecution.getJobInstance();
+        // Then
+        assertThat(ExitStatus.COMPLETED).isEqualTo(jobExecution.getExitStatus());
+        assertThat("expirePassTicketsJob").isEqualTo(jobInstance.getJobName());
+    }
+
+    private void addPassEntities(int size) {
+        final LocalDateTime now = LocalDateTime.now();
+        final Random random = new Random();
+
+        List<PassTicket> passEntities = new ArrayList<>();
+        for (int i = 0; i < size; ++i) {
+            PassTicket passTicket = PassTicket.of(
+                    1L,
+                    "A" + 1000000 + i,
+                    PassTicketStatus.PROGRESSED,
+                    random.nextInt(11),
+                    now.minusDays(60),
+                    now.minusDays(1),
+                    null
+            );
+            passEntities.add(passTicket);
+
+        }
+        passTicketRepository.saveAll(passEntities);
+    }
+}

--- a/src/test/java/com/spring/pass/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/spring/pass/repository/JpaRepositoryTest.java
@@ -1,12 +1,13 @@
 package com.spring.pass.repository;
 
+import com.spring.pass.config.TestJpaConfig;
 import com.spring.pass.domain.Booking;
 import com.spring.pass.domain.Package;
 import com.spring.pass.domain.PassTicket;
 import com.spring.pass.domain.UserAccount;
 import com.spring.pass.domain.constant.BookingStatus;
-import com.spring.pass.domain.constant.PassStatus;
-import com.spring.pass.domain.constant.UserStatus;
+import com.spring.pass.domain.constant.PassTicketStatus;
+import com.spring.pass.domain.constant.UserAccountStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ import static org.assertj.core.api.Assertions.*;
 class JpaRepositoryTest {
 
     @DisplayName("Booking Jpa 테스트")
-    @Import(JpaRepositoryTest.TestJpaConfig.class)
+    @Import(TestJpaConfig.class)
     @DataJpaTest
     @Nested
     class BookingJpaTest {
@@ -57,7 +58,7 @@ class JpaRepositoryTest {
             Booking booking = Booking.of(
                     1L,
                     "A1000000",
-                    BookingStatus.IN_PROGRESS,
+                    BookingStatus.PROGRESSED,
                     true,
                     true,
                     LocalDateTime.now(),
@@ -84,7 +85,7 @@ class JpaRepositoryTest {
     }
 
     @DisplayName("Package Jpa 테스트")
-    @Import(JpaRepositoryTest.TestJpaConfig.class)
+    @Import(TestJpaConfig.class)
     @DataJpaTest
     @Nested
     class PackageJpaTest {
@@ -136,7 +137,7 @@ class JpaRepositoryTest {
     }
 
     @DisplayName("PassTicket Jpa 테스트")
-    @Import(JpaRepositoryTest.TestJpaConfig.class)
+    @Import(TestJpaConfig.class)
     @DataJpaTest
     @Nested
     class PassTicketJpaTest {
@@ -166,7 +167,7 @@ class JpaRepositoryTest {
             PassTicket passTicket = PassTicket.of(
                     3L,
                     "A1000002",
-                    PassStatus.IN_PROGRESS,
+                    PassTicketStatus.PROGRESSED,
                     20,
                     LocalDateTime.now(),
                     LocalDateTime.now().plusDays(1),
@@ -192,7 +193,7 @@ class JpaRepositoryTest {
     }
 
     @DisplayName("UserAccount Jpa 테스트")
-    @Import(JpaRepositoryTest.TestJpaConfig.class)
+    @Import(TestJpaConfig.class)
     @DataJpaTest
     @Nested
     class UserAccountJpaTest {
@@ -222,7 +223,7 @@ class JpaRepositoryTest {
             UserAccount userAccount = UserAccount.of(
                     "C1000000",
                     "김주영",
-                    UserStatus.ACTIVE,
+                    UserAccountStatus.ACTIVE,
                     "01012341234",
                     null
             );
@@ -244,10 +245,5 @@ class JpaRepositoryTest {
             // Then
             assertThat(userAccountRepository.count()).isEqualTo(previousCount - 1);
         }
-    }
-
-    @EnableJpaAuditing
-    @TestConfiguration
-    public static class TestJpaConfig {
     }
 }


### PR DESCRIPTION
- status 파일명 rename 및 필드 수정
    - #3에서의 도메인 name 수정에 따라 status도 rename
    - Booking, PassTicket의 status 필드 중 `IN_PROGRESS -> PROGRESSED` 수정

- 필드 수정 메소드 추가
    - 만료 일시(expiredAt), 상태(status)를 수정하는 메소드 추가

- 이용권 만료 기능 구현
    - Spring Batch 사용을 위한 config 추가
    - 무결성 문제를 피하기위해 Cusor(`JpaCursorItemReader`, `JpaItemWriter`)를 사용하고 Chunk 단위로 트랜잭션을 처리하는 이용권 만료 기능 Job을 구현

- 테스트를 위한 Lombok Dependency 추가

- 이용권 만료 기능 테스트
    - 테스트를 위한 `TestBatchConfig` 추가
    - 테스트에서의 JPA Auditing 기능을 `JpaRepositoryTest`에서만 사용하지 않기때문에 확장성을 위해 `TestJpaConfig`를 추가
    - `ApplicationTest`는 `test` pofile의 properties를 사용하도록 설정

Closes: #6 