### PR TITLE
Job 컨트롤러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'io.hypersistence:hypersistence-utils-hibernate-55:3.5.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.batch:spring-batch-integration'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.opencsv:opencsv:5.7.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/spring/pass/config/BatchConfig.java
+++ b/src/main/java/com/spring/pass/config/BatchConfig.java
@@ -1,6 +1,9 @@
 package com.spring.pass.config;
 
+import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -13,4 +16,13 @@ import org.springframework.context.annotation.Configuration;
 @EnableBatchProcessing
 @Configuration
 public class BatchConfig {
+    /**
+     *  JobRegistryBeanPostProcessor 는 Application Context가 올라가면서 bean 등록 시 자동으로 JobRegistry에 Job을 등록
+     */
+    @Bean
+    public JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor(JobRegistry jobRegistry) {
+        JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor = new JobRegistryBeanPostProcessor();
+        jobRegistryBeanPostProcessor.setJobRegistry(jobRegistry);
+        return jobRegistryBeanPostProcessor;
+    }
 }

--- a/src/main/java/com/spring/pass/controller/JobLauncherController.java
+++ b/src/main/java/com/spring/pass/controller/JobLauncherController.java
@@ -1,0 +1,26 @@
+package com.spring.pass.controller;
+
+import com.spring.pass.dto.request.JobLauncherRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("job")
+public class JobLauncherController {
+    private final JobLauncher jobLauncher;
+    private final JobRegistry jobRegistry;
+
+    @PostMapping("/launcher")
+    public ExitStatus launcherJob(@RequestBody JobLauncherRequest request) throws Exception {
+        Job job = jobRegistry.getJob(request.name());
+        return jobLauncher.run(job, request.getJobParameters()).getExitStatus();
+    }
+}

--- a/src/main/java/com/spring/pass/dto/request/JobLauncherRequest.java
+++ b/src/main/java/com/spring/pass/dto/request/JobLauncherRequest.java
@@ -1,0 +1,15 @@
+package com.spring.pass.dto.request;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+
+import java.util.Properties;
+
+public record JobLauncherRequest(
+        String name,
+        Properties jobParameters
+) {
+    public JobParameters getJobParameters() {
+        return new JobParametersBuilder(jobParameters).toJobParameters();
+    }
+}

--- a/src/main/java/com/spring/pass/job/notification/SendNotificationBeforeClassJobConfig.java
+++ b/src/main/java/com/spring/pass/job/notification/SendNotificationBeforeClassJobConfig.java
@@ -58,7 +58,7 @@ public class SendNotificationBeforeClassJobConfig {
      * Cursor 기법의 ItemReader는 thread-safe하지 않아 Paging 기법을 사용하거나 synchronized 를 선언하여 순차적으로 수행
      * Paging의 경우 무결성 문제가 있기 때문에 이를 고려하여 synchronized로 사용
      */
-    @Bean
+    @Bean(destroyMethod = "")
     public JpaPagingItemReader<Booking> addNotificationItemReader() {
         return new JpaPagingItemReaderBuilder<Booking>()
                 .name("addNotificationItemReader")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,13 @@ spring:
     hikari:
       maximum-pool-size: 20
   batch:
+    job:
+      # true는 Spring Boot 실행 시 등록되어 있는 Job들을 실행
+      enabled: false
     jdbc:
       initialize-schema: always
+      # JPA does not support custom isolation levels, so locks may not be taken when launching Jobs. To silence this warning, set 'spring.batch.jdbc.isolation-level-for-create' to 'default'.
+      isolation-level-for-create: default
 
 kakao:
   host: https://kapi.kakao.com

--- a/src/test/java/com/spring/pass/config/TestBatchConfig.java
+++ b/src/test/java/com/spring/pass/config/TestBatchConfig.java
@@ -1,15 +1,13 @@
 package com.spring.pass.config;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@TestConfiguration
+@Import(BatchConfig.class)
 @EnableAutoConfiguration
-@EnableBatchProcessing
 @EntityScan("com.spring.pass.domain")
 @EnableJpaRepositories("com.spring.pass.repository")
 @EnableTransactionManagement


### PR DESCRIPTION
- Job 등록을 위한 Bean 등록
    - `JobRegistryBeanPostProcessor` 을 사용하여 `JobRegistry` 에 Job 을 등록

- Job 컨트롤러 추가
    - request DTO 추가
    - job name과 `jobparameters를 받아 실행

- destroy method Warning 문제를 `destroyMethod = ""` 로 지정하여 해결

- Update properties
    - Spring Boot 실행시 등록되어있는 Job들이 실행되지 않도록 설정
    - `isolation-level` 관련 Warning 해결을 위한 설정

- `Spring Web` Dependency 추가

- `TestBatchConfig`에서 `BatchConfig`를 Import하도록 수정

Closes: #25 